### PR TITLE
Ignore built files in the generated project

### DIFF
--- a/{{cookiecutter.extension_name}}/.gitignore
+++ b/{{cookiecutter.extension_name}}/.gitignore
@@ -1,0 +1,4 @@
+*.bundle.*
+lib/
+node_modules/
+*.egg-info/


### PR DESCRIPTION
There's a gitignore in the root, but it's also handy to have one
in the generated project so would-be extension writers don't have
to figure out what should and should not be checked into git.