### PR TITLE
Add supported extension types and subdirectories

### DIFF
--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -14,8 +14,7 @@
     "prepublish": "npm run build"
   },
   "files": [
-    "lib/*.d.ts",
-    "lib/*.js"
+    "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}"
   ],
   "jupyterlab": {
     "extension": true


### PR DESCRIPTION
This
- adds all the extension types that are [currently allowed](https://jupyterlab-tutorial.readthedocs.io/en/latest/extensions_dev.html#extension-authoring)
- handles subdirectories

Both of these have tripped me up in the move to `npm`-style extensions.

Some follow-ons based on my experiences:
- add the simplest of css, 
  - with the pattern of `src` and `lib` both referring to styles from `../style`... 
  - I love `import("./style.css")` from a component for keeping code clean, but it is indeed simpler the way it is done now
- add the simplest `tsc --watch`
- add the simplest `jupyterlab build`
- add the simplest `jupyterlab extension link` 
- add the simplest test with `karma` or whatever
- add `tslint` (and watch): the defaults (which people's editors might pick up) don't reflect the style used by convention on the project
- add the simplest `jupyterlab build watch` (TBD)
- add a minimal `environment.yml` with `node`, `jupyterlab` and `cookiecutter`
- add a notebook in the root of this repo, or in the thing you get at the end of it, that can run all of the above... it's quite lovely to be able to _Run All` and refresh your browser, and see your new goodies running... or background some watch commands, and have it continuously update your environment

Happy to pitch in on any of these deemed valuable in helping grow the extension developer community!