### PR TITLE
Ensure keyword "jupyterlab extension"

### DIFF
--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "jupyter",
     "jupyterlab",
-    "jupyterlab extension"
+    "jupyterlab-extension"
   ],
   "homepage": "{{ cookiecutter.repository }}",
   "bugs": {

--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "description": "{{ cookiecutter.project_short_description }}",
   "keywords": [
-    "extension",
     "jupyter",
-    "jupyterlab"
+    "jupyterlab",
+    "jupyterlab extension"
   ],
   "homepage": "{{ cookiecutter.repository }}",
   "bugs": {


### PR DESCRIPTION
This should help with discoverability of published extensions, as it is a very specific keyword.