### PR TITLE
Update README

### DIFF
--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -3,30 +3,51 @@
 {{ cookiecutter.project_short_description }}
 
 
-## Prerequisites
+## Requirements
 
-* JupyterLab
+* JupyterLab >= 0.30.0 
 
-## Installation
+## Install
 
 ```bash
 jupyter labextension install {{ cookiecutter.extension_name }}
 ```
 
-## Development
+## Contributing
 
-For a development install (requires npm version 4 or later), do the following in the repository directory:
+### Install
+
+The `jlpm` command is JupyterLab's pinned version of
+[yarn](https://yarnpkg.com/) that is installed with JupyterLab. You may use
+`yarn` or `npm` in lieu of `jlpm` below.
 
 ```bash
-npm install
-npm run build
+# Clone the repo to your local environment
+# Move to {{ cookiecutter.extension_name }} directory
+# Install dependencies
+jlpm
+# Build Typescript source
+jlpm build
+# Link your development version of the extension with JupyterLab
 jupyter labextension link .
+# Rebuild Typescript source after making changes
+jlpm build
+# Rebuild JupyterLab after making any changes
+jupyter lab build
 ```
 
-To rebuild the package and the JupyterLab app:
+You can watch the source directory and run JupyterLab in watch mode to watch for changes in the extension's source and automatically rebuild the extension and application.
 
 ```bash
-npm run build
-jupyter lab build
+# Watch the source directory in another terminal tab
+jlpm watch
+# Run jupyterlab in watch mode in one terminal tab
+jupyter lab --watch
+```
+
+### Uninstall
+
+```bash
+jupyter labextension uninstall {{ cookiecutter.extension_name }}
 ```
 


### PR DESCRIPTION
This corrects the required JupyterLab version and install instructions and updates the "Contributing" section to be consistent with the extension in jupyter-renderers, which include some instructions about using the `watch` command.