### PR TITLE
Update JLab min version in README

### DIFF
--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -5,7 +5,7 @@
 
 ## Requirements
 
-* JupyterLab >= 0.30.0 
+* JupyterLab >= 1.0
 
 ## Install
 


### PR DESCRIPTION
Creating a new extension from this cookiecutter wouldn't work for 0.30 <= jupyterlab < 1.0.