### PR TITLE
Add GitHub Actions workflow to build the extension

### DIFF
--- a/{{cookiecutter.extension_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.extension_name}}/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install node
+      uses: actions/setup-node@v1
+      with:
+       node-version: '10.x'
+    - name: Install Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.7'
+        architecture: 'x64'
+    - name: Install dependencies
+      run: python -m pip install jupyterlab
+    - name: Build the extension
+      run: |
+        jlpm && jlpm run build
+        jupyter labextension install .
+        python -m jupyterlab.browser_check

--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -1,5 +1,7 @@
 # {{ cookiecutter.extension_name }}
 
+![Github Actions Status]({{ cookiecutter.repository }}/workflows/Build/badge.svg)
+
 {{ cookiecutter.project_short_description }}
 
 


### PR DESCRIPTION
Now that GitHub Actions have been rolled out to everyone, we can add a simple workflow to make sure the extension can be built.

This means that CI will be on and enabled by default if the extension is being developed on GitHub.

This change also adds a badge to the README file.