### PR TITLE
Switch to jlpm

### DIFF
--- a/{{cookiecutter.extension_name}}/package.json
+++ b/{{cookiecutter.extension_name}}/package.json
@@ -26,8 +26,8 @@
   },
   "scripts": {
     "build": "tsc",
-    "clean": "rimraf lib && rimraf tsconfig.tsbuildinfo",
-    "prepare": "npm run clean && npm run build",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "prepare": "jlpm run clean && jlpm run build",
     "watch": "tsc -w"
   },
   "dependencies": {


### PR DESCRIPTION
To be consistent with the [documentation](https://jupyterlab.readthedocs.io/en/stable/developer/extension_tutorial.html#extension-tutorial), we should use `jlpm` instead `npm` in `package.json` scripts.

Note: I simplify the `rimraf` syntax in this PR.