### PR TITLE
Add an opt-in binder

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -3,5 +3,6 @@
     "extension_name": "myextension",
     "project_short_description": "A JupyterLab extension.",
     "has_server_extension": "n",
+    "has_binder": "n",
     "repository": "https://github.com/my_name/myextension"
 }

--- a/cookiecutter_with_server.json
+++ b/cookiecutter_with_server.json
@@ -3,5 +3,6 @@
     "extension_name": "my-server_extension",
     "project_short_description": "A JupyterLab extension.",
     "has_server_extension": "y",
+    "has_binder": "n",
     "repository": "https://github.com/my_name/myextension"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -38,3 +38,6 @@ if __name__ == "__main__":
             for f in ("src/{{ cookiecutter.extension_name }}.ts", ):
                 absolute_f = PROJECT_DIRECTORY / f
                 absolute_f.rename(absolute_f.parent / absolute_f.name.replace("_", ""))
+
+    if not "{{ cookiecutter.has_binder }}".lower().startswith("y"):
+        remove_path(PROJECT_DIRECTORY / "binder")

--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -1,6 +1,9 @@
 # {{ cookiecutter.extension_name }}
 
 ![Github Actions Status]({{ cookiecutter.repository }}/workflows/Build/badge.svg)
+{%- if cookiecutter.has_binder.lower().startswith('y') -%}
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/master)
+{%- endif %}
 
 {{ cookiecutter.project_short_description }}
 

--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -2,7 +2,7 @@
 
 ![Github Actions Status]({{ cookiecutter.repository }}/workflows/Build/badge.svg)
 {%- if cookiecutter.has_binder.lower().startswith('y') -%}
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/master)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/master?urlpath=lab)
 {%- endif %}
 
 {{ cookiecutter.project_short_description }}

--- a/{{cookiecutter.extension_name}}/binder/environment.yml
+++ b/{{cookiecutter.extension_name}}/binder/environment.yml
@@ -1,0 +1,25 @@
+# a mybinder.org-ready environment for demoing {{ cookiecutter.extension_name }}
+# this environment may also be used locally on Linux/MacOS/Windows, e.g.
+#
+#   conda env update --file binder/environment.yml
+#   conda activate {{ cookiecutter.extension_name }}-demo
+#
+name: {{ cookiecutter.extension_name }}-demo
+
+channels:
+  - conda-forge
+
+dependencies:
+  # runtime dependencies
+  - python >=3.8,<3.9.0a0
+  - jupyterlab >=2,<3.0.0a0
+  # labextension build dependencies
+  - nodejs >=12,<13.0.0a0
+  {%- if cookiecutter.has_server_extension.lower().startswith('y') %}
+  # serverextension build dependencies
+  - jupyter-packaging >=0.4.0,<0.5.0a0
+  - pip
+  - wheel
+  {% endif %}
+  # additional packages for demos, may require modifying `labextensions.txt`
+  # - ipywidgets

--- a/{{cookiecutter.extension_name}}/binder/labextensions.txt
+++ b/{{cookiecutter.extension_name}}/binder/labextensions.txt
@@ -1,0 +1,6 @@
+# development install of {{ cookiecutter.extension_name }}
+.
+
+# some additional recommended labextensions, uncomment to enable
+# @jupyter-widgets/jupyterlab-manager
+# @jupyterlab/toc

--- a/{{cookiecutter.extension_name}}/binder/postBuild
+++ b/{{cookiecutter.extension_name}}/binder/postBuild
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+{%- set has_server_ext = cookiecutter.has_server_extension.lower().startswith('y') %}
+{%- set server_ext = cookiecutter.extension_name | replace("-", "_") %}
+""" perform a development install of {{ cookiecutter.extension_name }}{% if server_ext %} and {{ server_ext }}{% endif %}
+
+    On Binder, this will run _after_ the environment has been fully created from
+    the environment.yml in this directory.
+
+    This script should also run locally on Linux/MacOS/Windows:
+
+        python3 binder/postBuild
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path.cwd()
+LAB_EXTENSIONS = ROOT / "binder" / "labextensions.txt"
+
+if not LAB_EXTENSIONS.exists():
+    LAB_EXTENSIONS = ROOT / "labextensions.txt"
+
+
+def _(*args, **kwargs):
+    """ Run a command, echoing the args
+
+        fails hard if something goes wrong
+    """
+    print("\n\t", " ".join(args), "\n")
+    return_code = subprocess.call(args, **kwargs)
+    if return_code != 0:
+        print("\nERROR", return_code, " ".join(args))
+        sys.exit(return_code)
+
+{%- if has_server_ext %}
+# verify the environment is self-consistent before even starting
+_(sys.executable, "-m", "pip", "check")
+
+# install the labextension
+_(sys.executable, "-m", "pip", "install", "-e", ".")
+
+# verify the environment the extension didn't break anything
+_(sys.executable, "-m", "pip", "check")
+
+# enable the serverextension (normally would be handled by package_data)
+_("jupyter", "serverextension", "enable", "--sys-prefix", "--py", "{{ server_ext }}")
+
+# list the extensions
+_("jupyter", "serverextension", "list")
+{% endif -%}
+
+# install dependencies
+_("jlpm")
+
+# initially list installed extensions to determine if there are any surprises
+_("jupyter", "labextension", "list")
+
+# install the labextension
+_("jupyter", "labextension", "install", "--no-build", "--debug",
+    *[
+        ext.strip()
+        for ext in LAB_EXTENSIONS.read_text().splitlines()
+        if ext.strip() and not ext.strip().startswith("#")
+    ]
+)
+
+# verify the list of extensions
+_("jupyter", "labextension", "list")
+
+# verify the list of extensions
+_("jupyter", "lab", "build", "--dev-build=False", "--minimize=True")
+
+# verify the list of extensions one last time
+_("jupyter", "labextension", "list")
+
+print("JupyterLab with {{ cookiecutter.extension_name }} is ready to run with:\n")
+print("\tjupyter lab\n")


### PR DESCRIPTION
While having GitHub CI is cool, demos are even cooler for getting people spun up and experiencing shareable success quickly.

This adds an opt-in `has_binder` switch which will create a fairly-opinionated binder (or local) environment based on a `binder` folder with:
- an `environment.yml`
  - because binder is already conda-based, and will predictably work on windows
    - and pinning node/lab versions is a Good Thing
- a python-based `postBuild`
  - because bash is scary, see point above about windows
- a simple `labextensions.txt` with the extension-under-demo as well as some recommendations
  - because we don't have a "real" file description

Also further populated badgeopolis in the README.

I haven't added anything to the tests... maybe should be black/flake8 checking output python, but otherwise there's no code added.