### PR TITLE
Enable serverextension under sys.prefix

### DIFF
--- a/{{cookiecutter.extension_name}}/README.md
+++ b/{{cookiecutter.extension_name}}/README.md
@@ -68,7 +68,7 @@ The `jlpm` command is JupyterLab's pinned version of
 # Install server extension
 pip install -e .
 # Register server extension
-jupyter serverextension enable --py {{ cookiecutter.extension_name|replace("-", "_") }}
+jupyter serverextension enable --py {{ cookiecutter.extension_name|replace("-", "_") }} --sys-prefix
 {% endif %}
 # Install dependencies
 jlpm


### PR DESCRIPTION
This enables the extension only in the current venv/conda env.
Anywhere else, the extension will fail to load as the package
isn't available.