### PR TITLE
Use a stable lab version on CI instead of a prerelease

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
         architecture: 'x64'
     - name: Install dependencies
       run: |
-        python -m pip install --pre jupyterlab
+        python -m pip install jupyterlab
         python -m pip install cookiecutter
     - name: Create pure frontend extension
       run: |


### PR DESCRIPTION
The periodic CI check started to fail a couple of days ago.

Here is an example of such build: https://github.com/jupyterlab/extension-cookiecutter-ts/runs/820559135?check_suite_focus=true

This is because CI was installing a pre-release version of JupyterLab.
