### PR TITLE
Include yarn.lock in manifest

### DIFF
--- a/{{cookiecutter.python_name}}/MANIFEST.in
+++ b/{{cookiecutter.python_name}}/MANIFEST.in
@@ -5,6 +5,7 @@ include jupyter-config/{{ cookiecutter.python_name }}.json
 
 include package.json
 include ts*.json
+include yarn.lock
 
 graft {{ cookiecutter.python_name }}/static
 


### PR DESCRIPTION
When installing from an sdist, pip will run the bdist_wheel command, rebuilding the JS source. This cookicutter currently uses `jlpm` as the install command. For this reason it makes sense to include the yarn.lock file (a set of dependencies that are known to produce a working build).