### PR TITLE
Update python lab version specifier

### DIFF
--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.0", "jupyterlab~=3.0.0b6", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.0", "jupyterlab>=3.0.0b6,==3.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -65,7 +65,7 @@ setup_args = dict(
     cmdclass= cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
-        "jupyterlab~=3.0.0b6",
+        "jupyterlab>=3.0.0b6,==3.*",
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/extension-cookiecutter-ts/issues/92

Puts the allowed range to the entire 3.x range (from b6 and up).