### PR TITLE
Enable strictNullChecks by default

### DIFF
--- a/{{cookiecutter.python_name}}/tsconfig.json
+++ b/{{cookiecutter.python_name}}/tsconfig.json
@@ -16,7 +16,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "strict": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "target": "es2017",
     "types": []
   },


### PR DESCRIPTION
Fixes #71. 

We should check whether we want to have `strictNullChecks` set to `true` by default in the cookiecutter for 3.0, as this might also require updating a couple of other places that depend on the cookiecutter and use the `python -m jupyterlab.upgrade_extension` script:

- apod tutorial: https://jupyterlab.readthedocs.io/en/latest/developer/extension_tutorial.html
- extension examples: https://github.com/jupyterlab/extension-examples