### PR TITLE
Ensure python and node versions remain coherent

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -1,13 +1,15 @@
 """
 {{ cookiecutter.python_name }} setup
 """
+import json
 import os
 
 from jupyter_packaging import (
     create_cmdclass, install_npm, ensure_targets,
-    combine_commands, get_version,
+    combine_commands,
 )
 import setuptools
+
 
 HERE = os.path.abspath(os.path.dirname(__file__))
 
@@ -15,7 +17,10 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 name="{{ cookiecutter.python_name }}"
 
 # Get our version
-version = get_version(os.path.join(name, "_version.py"))
+# TODO use version = get_version(os.path.join(name, "_version.py")) 
+# from jupyter_packaging which fails with NameError: name '__file__' is not defined.
+with open('package.json') as f:
+    version = json.load(f)['version']
 
 lab_path = os.path.join(HERE, name, "static")
 

--- a/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/__init__.py
+++ b/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/__init__.py
@@ -4,6 +4,9 @@ import os.path as osp
 
 from ._version import __version__
 
+
+VERSION_INFO = __version__
+
 HERE = osp.abspath(osp.dirname(__file__))
 
 with open(osp.join(HERE, 'static', 'package.json')) as fid:

--- a/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
+++ b/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
@@ -1,2 +1,9 @@
-version_info = (0, 1, 0)
-__version__ = ".".join(map(str, version_info))
+import json
+import os.path as osp
+
+HERE = osp.abspath(osp.dirname(__file__))
+
+with open(osp.join(HERE, 'package.json')) as fid:
+    data = json.load(fid)
+
+__version__ = pdata['version']

--- a/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
+++ b/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
@@ -3,7 +3,7 @@ import os.path as osp
 
 HERE = osp.abspath(osp.dirname(__file__))
 
-with open(osp.join(HERE, 'package.json')) as fid:
-    data = json.load(fid)
+with open(osp.join(HERE, 'static', 'package.json')) as fid:
+    pdata = json.load(fid)
 
 __version__ = pdata['version']


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/extension-cookiecutter-ts/issues/102

Get Python version from package.json

Port of https://github.com/jtpio/jupyterlab-python-file/pull/19