### PR TITLE
Switch GitHub Actions workflow to target the main branch

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: master
+    branches: [ main ]
   pull_request:
     branches: '*'
 

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -2,7 +2,7 @@
 
 ![Github Actions Status]({{ cookiecutter.repository }}/workflows/Build/badge.svg)
 {%- if cookiecutter.has_binder.lower().startswith('y') -%}
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/main?urlpath=lab)
 {%- endif %}
 
 {{ cookiecutter.project_short_description }}


### PR DESCRIPTION
Since new repos on GitHub are now using `main` as the main branch, we can update the CI workflow to target `main`.

This change also updates the Binder link to point to the `main` branch.