### PR TITLE
Update data_files_spec glob to include nested directories

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -34,7 +34,7 @@ package_data_spec = {
 labext_name = "{{ cookiecutter.labextension_name }}"
 
 data_files_spec = [
-    ("share/jupyter/labextensions/%s" % labext_name, lab_path, "*.*"),
+    ("share/jupyter/labextensions/%s" % labext_name, lab_path, "**"),
     {%- if cookiecutter.has_server_extension == "y" -%}
     ("etc/jupyter/jupyter_server_config.d",
      "jupyter-config", "{{ cookiecutter.python_name }}.json"),


### PR DESCRIPTION
While upgrading an extension that has a setting file, the wheel didn't contain the `schemas` directory but the `sdist` did.

This change updates the glob pattern to also include nested directories such as settings files for extensions.