### PR TITLE
Treat package.json as sole source of version truth, get python version from that

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -1,6 +1,7 @@
 """
 {{ cookiecutter.python_name }} setup
 """
+import json
 import os
 
 from jupyter_packaging import (
@@ -15,7 +16,8 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 name="{{ cookiecutter.python_name }}"
 
 # Get our version
-version = get_version(os.path.join(name, "_version.py"))
+with open(os.path.join(HERE, 'package.json')) as f:
+    version = json.load(f)['version']
 
 lab_path = os.path.join(HERE, name, "static")
 

--- a/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
+++ b/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
@@ -1,2 +1,19 @@
-version_info = (0, 1, 0)
-__version__ = ".".join(map(str, version_info))
+__all__ = ['__version__']
+
+def _fetchVersion():
+    import json
+    import os
+
+    HERE = os.path.abspath(os.path.dirname(__file__))
+
+    for d, _, _ in os.walk(HERE): 
+        try:
+            with open(os.path.join(d, 'package.json')) as f:
+                return json.load(f)['version']
+        except FileNotFoundError:
+            pass
+
+    raise FileNotFoundError('Could not find package.json under dir {}'.format(HERE))
+
+__version__ = _fetchVersion()
+


### PR DESCRIPTION
This PR makes it so that version is fetched from <ext-name>'s `package.json` during installation of the python package in `setup.py`, and when someone does `import <ext-name>; <ext-name>.__version__`.

To give some extra flexibility w.r.t. project structure, the version lookup for `<ext-name>.__version__` will look for `package.json` in the install dir of the `<ext-name>` python package, as well as any subdirs. This is needed for the default python package produced by the cookiecutter, which currently places `package.json` at `<ext-name>/static/package.json`.