### PR TITLE
Remove jupyter labextension uninstall from README

### DIFF
--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -83,5 +83,4 @@ jupyter lab build --minimize=False
 
 ```bash
 pip uninstall {{ cookiecutter.python_name }}
-jupyter labextension uninstall {{ cookiecutter.labextension_name }}
 ```


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/extension-cookiecutter-ts/pull/109