### PR TITLE
Use Node 12 on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install node
       uses: actions/setup-node@v1
       with:
-       node-version: '10.x'
+       node-version: '12.x'
     - name: Install Python
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
To match: 

https://github.com/jupyterlab/jupyterlab/blob/05e704f20cc3358e3066adef8273a602a3f76e91/.github/workflows/linuxjs-tests.yml#L22

And the bump to node 12 in the latest lab as minimal requirement.

