### PR TITLE
Read version with get_version in setup.py

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -1,7 +1,6 @@
 """
 {{ cookiecutter.python_name }} setup
 """
-import json
 import os
 
 from jupyter_packaging import (
@@ -15,9 +14,7 @@ HERE = os.path.abspath(os.path.dirname(__file__))
 # The name of the project
 name="{{ cookiecutter.python_name }}"
 
-# Get our version
-with open(os.path.join(HERE, 'package.json')) as f:
-    version = json.load(f)['version']
+version = get_version(os.path.join(name, "_version.py"))
 
 lab_path = os.path.join(HERE, name, "labextension")
 


### PR DESCRIPTION
Since the version is now fetched from `package.json` in `_version.py` (https://github.com/jupyterlab/extension-cookiecutter-ts/pull/108) we might as well switch back to using `get_version` in `setup.py`.