### PR TITLE
Skip building js assets if they already exist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,8 +34,8 @@ jobs:
       run: |
         cookiecutter . --no-input
         cd myextension
+        jlpm install && jlpm run eslint:check
         pip install -e .
-        jlpm run eslint:check
         jupyter labextension list 1>labextensions 2>&1
         cat labextensions | grep "myextension.*OK"
         python -m jupyterlab.browser_check

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.7", "jupyterlab>=3.0.0rc13,==3.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.9", "jupyterlab>=3.0.0rc13,==3.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["jupyter_packaging~=0.7.0", "jupyterlab>=3.0.0rc13,==3.*", "setuptools>=40.8.0", "wheel"]
+requires = ["jupyter_packaging~=0.7.7", "jupyterlab>=3.0.0rc13,==3.*", "setuptools>=40.8.0", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -6,7 +6,7 @@ import os
 
 from jupyter_packaging import (
     create_cmdclass, install_npm, ensure_targets,
-    combine_commands, get_version,
+    combine_commands, skip_if_exists
 )
 import setuptools
 
@@ -49,10 +49,16 @@ cmdclass = create_cmdclass("jsdeps",
     data_files_spec=data_files_spec
 )
 
-cmdclass["jsdeps"] = combine_commands(
+js_command = combine_commands(
     install_npm(HERE, build_cmd="build:prod", npm=["jlpm"]),
     ensure_targets(jstargets),
 )
+
+is_repo = os.path.exists(os.path.join(HERE, ".git"))
+if is_repo:
+    cmdclass["jsdeps"] = js_command
+else:
+    cmdclass["jsdeps"] = skip_if_exists(jstargets, js_command)
 
 with open("README.md", "r") as fh:
     long_description = fh.read()


### PR DESCRIPTION
Using `skip_if_exists` from `jupyter_packaging` added in https://github.com/jupyter/jupyter-packaging/pull/54

This avoids rebuilding the assets if they already exist (for example in the source tarball).

The main motivation is to make it easier to package for conda, to avoid the dependency on `jupyterlab` / `jlpm`.
