### PR TITLE
Remove the lib js target

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -23,7 +23,6 @@ lab_path = os.path.join(HERE, name, "labextension")
 
 # Representative files that should exist after a successful build
 jstargets = [
-    os.path.join(HERE, "lib", "index.js"),
     os.path.join(lab_path, "package.json"),
 ]
 


### PR DESCRIPTION
Since `lib` is pruned here:

https://github.com/jupyterlab/extension-cookiecutter-ts/blob/fb8de6e99ee29ea0f11aecf1f49b044e1023e319/%7B%7Bcookiecutter.python_name%7D%7D/MANIFEST.in#L16

It will not be part of the sdist, and will be a missing js target. Which means that even with https://github.com/jupyterlab/extension-cookiecutter-ts/pull/121, it looks like it will still trigger a build.

Not sure we could rely on any other files in `outputDir/static/` since their names are generated. So we might just want to keep `outputDir/package.json`?