### PR TITLE
Change the default branch from master to main

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build
 
 on:
   push:
-    branches: master
+    branches: main
   pull_request:
     branches: '*'
 

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -2,7 +2,7 @@
 
 ![Github Actions Status]({{ cookiecutter.repository }}/workflows/Build/badge.svg)
 {%- if cookiecutter.has_binder.lower().startswith('y') -%}
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/master?urlpath=lab)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/main?urlpath=lab)
 {%- endif %}
 
 {{ cookiecutter.project_short_description }}


### PR DESCRIPTION
Now github [default](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/#:~:text=The%20default%20branch%20name%20for,.com%2Fsettings%2Frepositories%20page) branch name is `main` rather than `master`. The new extension projects built from the template should be modified as well.