### PR TITLE
Include yarn.lock in manifest

### DIFF
--- a/{{cookiecutter.python_name}}/MANIFEST.in
+++ b/{{cookiecutter.python_name}}/MANIFEST.in
@@ -6,6 +6,7 @@ include jupyter-config/{{ cookiecutter.python_name }}.json
 include package.json
 include install.json
 include ts*.json
+include yarn.lock
 
 graft {{ cookiecutter.python_name }}/labextension
 


### PR DESCRIPTION
It looks like https://github.com/jupyterlab/extension-cookiecutter-ts/pull/91#event-4211646005 was merged into the `3.0`.

This PR is raised against `master`.