### PR TITLE
Enable CI on all branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: 'master'
+    branches: '*'
   pull_request:
     branches: '*'
   schedule:


### PR DESCRIPTION
Looks like CI has stopped running on the main branch (currently 3.0):

![image](https://user-images.githubusercontent.com/591645/114902554-3a543b80-9e16-11eb-998c-7558cd84242c.png)


Which is most likely related to the rename.