### PR TITLE
Fix CI fail on initial push of newly created extension

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -64,7 +64,6 @@ jobs:
         python -m build --sdist
         cp dist/*.tar.gz myextension.tar.gz
         pip uninstall -y myextension jupyterlab
-        popd
         rm -rf myextension
 
     - uses: actions/upload-artifact@v2

--- a/{{cookiecutter.python_name}}/MANIFEST.in
+++ b/{{cookiecutter.python_name}}/MANIFEST.in
@@ -15,6 +15,7 @@ graft src
 graft style
 prune **/node_modules
 prune lib
+prune binder
 
 # Patterns to exclude from any directory
 global-exclude *~


### PR DESCRIPTION
First of all thanks for the cookiecutter template ❤️

Sadly it doesn't always work out of the box.

When creating a new extension and choosing `has_binder [n]: y` the [initial push fails](https://github.com/s-weigand/jupyterlab_autosave_on_focus_change/runs/2636475282?check_suite_focus=true) due to `check-manifest` complaining about the `binder` folder not being in the `MANIFEST.in`.
Since the binder settings aren't needed for the extension itself, this can be fixed by excluding them from packaging.

After fixing this there is an [error caused by `popd`](https://github.com/s-weigand/jupyterlab_autosave_on_focus_change/runs/2636549005?check_suite_focus=true) (`directory stack empty`) since `pushd` wasn't used in the workflow.

After removing `popd` from the workflow template a freshly created extension [passes the CI](https://github.com/s-weigand/jupyterlab_autosave_on_focus_change/actions/runs/862884900).