### PR TITLE
Cover PR 167 issue seen in extension-example

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,7 +250,7 @@ jobs:
           jupyter labextension uninstall myextension
           pip uninstall -y myextension jupyterlab
 
-          rm -rf myextension
+          python -c "import shutil; shutil.rmtree('myextension')"
 
       - name: Install server extension from a tarball
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -260,7 +260,8 @@ jobs:
           pip install --pre jupyterlab
           jupyter lab clean --all
           python -m build --sdist
-          pip install dist/*.tar.gz
+          cd dist
+          pip install myextension-0.1.0.tar.gz
 
       - name: Check install tarball method
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -199,7 +199,6 @@ jobs:
 
       - name: Create server extension pip install
         run: |
-          set -eux
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
@@ -208,6 +207,7 @@ jobs:
 
       - name: Check pip install method
         run: |
+          set -eux
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
           jupyter labextension list
@@ -222,7 +222,6 @@ jobs:
 
       - name: Create server extension pip develop
         run: |
-          set -eux
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
@@ -233,6 +232,7 @@ jobs:
 
       - name: Check pip develop method
         run: |
+          set -eux
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
           jupyter labextension list
@@ -254,7 +254,6 @@ jobs:
 
       - name: Install server extension from a tarball
         run: |
-          set -eux
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
@@ -265,6 +264,7 @@ jobs:
 
       - name: Check install tarball method
         run: |
+          set -eux
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -152,7 +152,11 @@ jobs:
           rm -rf myextension
 
   server:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -198,40 +202,48 @@ jobs:
           set -eux
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
-          pushd myextension
+          cd myextension
           pip install .
           pip install jupyterlab
+
+      - name: Check pip install method
+        run: |
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
-          popd
+
           # This test should be made outside the extension folder
           python -m jupyterlab.browser_check
 
           pip uninstall -y myextension jupyterlab
           rm -rf myextension
+        shell: bash
 
       - name: Create server extension pip develop
         run: |
           set -eux
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
-          pushd myextension
+          cd myextension
           pip install -e .
           pip install jupyterlab
           jupyter labextension develop . --overwrite
           jupyter server extension enable myextension
+
+      - name: Check pip develop method
+        run: |
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
 
-          popd
-
           # This test should be made outside the extension folder
           python -m jupyterlab.browser_check
+        shell: bash
 
+      - name: Build server extension in develop mode
+        run: |
           jupyter labextension develop ./myextension --overwrite
           jupyter labextension build ./myextension
 
@@ -245,26 +257,30 @@ jobs:
           set -eux
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
-          pushd myextension
+          cd myextension
           pip install --pre jupyterlab
           jupyter lab clean --all
           python -m build --sdist
           pip install dist/*.tar.gz
+
+      - name: Check install tarball method
+        run: |
           jupyter labextension list
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
 
           jupyter lab build --dev-build --no-minimize
-          popd
 
           python -m jupyterlab.browser_check
 
           cp myextension/dist/*.tar.gz myextension.tar.gz
           pip uninstall -y myextension jupyterlab
           rm -rf myextension
+        shell: bash
 
       - uses: actions/upload-artifact@v2
+        if: startsWith(runner.os, 'Linux')
         with:
           name: myextension-sdist
           path: myextension.tar.gz

--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -22,8 +22,8 @@ ensured_targets = [
 labext_name = "{{ cookiecutter.labextension_name }}"
 
 data_files_spec = [
-    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
-    ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
+    ("share/jupyter/labextensions/%s" % labext_name, str(lab_path.relative_to(HERE)), "**"),
+    ("share/jupyter/labextensions/%s" % labext_name, str('.'), "install.json"),
     {%- if cookiecutter.has_server_extension == "y" -%}
     ("etc/jupyter/jupyter_server_config.d",
      "jupyter-config/server-config", "{{ cookiecutter.python_name }}.json"),


### PR DESCRIPTION
In https://github.com/jupyterlab/extension-examples/pull/167, we hit an error on Windows to list the data files. This push the fix in the cookiecutter to ensure people using it on Windows won't hit it.

Side-effetct: Add test of server extension on all OSes