### PR TITLE
Revert "Revert "Add pypi classifiers (#174)""

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -65,11 +65,10 @@ setup_args = dict(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Framework :: Jupyter",
-        # These classifiers will be valid when https://github.com/pypa/warehouse/pull/9882 gets merged
-        # "Framework :: Jupyter :: JupyterLab",
-        # "Framework :: Jupyter :: JupyterLab :: 3",
-        # "Framework :: Jupyter :: JupyterLab :: Extensions",
-        # "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
+        "Framework :: Jupyter :: JupyterLab",
+        "Framework :: Jupyter :: JupyterLab :: 3",
+        "Framework :: Jupyter :: JupyterLab :: Extensions",
+        "Framework :: Jupyter :: JupyterLab :: Extensions :: Prebuilt",
     ],
 )
 


### PR DESCRIPTION
Reverts jupyterlab/extension-cookiecutter-ts#175

I verified that publishing now works with the spellchecker: https://pypi.org/search/?q=&o=&c=Framework+%3A%3A+Jupyter+%3A%3A+JupyterLab+%3A%3A+Extensions :tada: