### PR TITLE
Handle pre-releases for the Python version

### DIFF
--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -36,10 +36,16 @@ long_description = (HERE / "README.md").read_text()
 
 # Get the package info from package.json
 pkg_json = json.loads((HERE / "package.json").read_bytes())
+version = (
+    pkg_json["version"]
+    .replace("-alpha.", "a")
+    .replace("-beta.", "b")
+    .replace("-rc.", "rc")
+) 
 
 setup_args = dict(
     name=name,
-    version=pkg_json["version"],
+    version=version,
     url=pkg_json["homepage"],
     author=pkg_json["author"]["name"],
     author_email=pkg_json["author"]["email"],

--- a/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
+++ b/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/_version.py
@@ -9,7 +9,12 @@ def _fetchVersion():
     for settings in HERE.rglob("package.json"): 
         try:
             with settings.open() as f:
-                return json.load(f)["version"]
+                version = json.load(f)["version"]
+                return (
+                    version.replace("-alpha.", "a")
+                    .replace("-beta.", "b")
+                    .replace("-rc.", "rc")
+                )
         except FileNotFoundError:
             pass
 


### PR DESCRIPTION
The cookiecutter makes versioning convenient with the version being read from the `package.json`, and used for the Python package.

This is handy for example when using the Jupyter Releaser, so we don't need a dedicated script to bump the version and manage a single version number for both the npm and Python packages.

This change adds support for pre-releases so they are explicitly normalized for the Python package.