### PR TITLE
Add default CHANGELOG.md

### DIFF
--- a/{{cookiecutter.python_name}}/CHANGELOG.md
+++ b/{{cookiecutter.python_name}}/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+<!-- <START NEW CHANGELOG ENTRY> -->
+
+<!-- <END NEW CHANGELOG ENTRY> -->

--- a/{{cookiecutter.python_name}}/MANIFEST.in
+++ b/{{cookiecutter.python_name}}/MANIFEST.in
@@ -1,6 +1,5 @@
 include LICENSE
-include README.md
-include RELEASE.md
+include *.md
 include pyproject.toml{% if cookiecutter.has_server_extension == "y" %}
 recursive-include jupyter-config *.json{% endif %}
 


### PR DESCRIPTION
Add a default `CHANGELOG.md` so the releaser can be used out of the box.
