### PR TITLE
Add `publishConfig` to `package.json`

### DIFF
--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -70,6 +70,9 @@
     "style/index.js"
   ],
   "styleModule": "style/index.js",
+  "publishConfig": {
+    "access": "public"
+  },
   "jupyterlab": { {% if cookiecutter.has_server_extension.lower().startswith('y') %}
     "discovery": {
         "server": {


### PR DESCRIPTION
Add `publishConfig` to `package.json` to make the repo compatible with the Jupyter Releaser out of the box and be able to publish to `npm`.