### PR TITLE
Add a CI step to upload the distributions built by the releaser

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/check-release.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/check-release.yml
@@ -53,3 +53,8 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Distributions
+        uses: actions/upload-artifact@v2
+        with:
+          name: {{ cookiecutter.python_name }}-releaser-dist-${{ github.run_number }}
+          path: .jupyter_releaser_checkout/dist


### PR DESCRIPTION
This is useful so the distributions could be inspected if needed, to make sure everything looks right or works locally before releasing.

Example:

![image](https://user-images.githubusercontent.com/591645/136426058-80667f6d-c761-48ff-92a4-16da41ca2f6b.png)
