### PR TITLE
Include LICENSE file explicitly in package

### DIFF
--- a/{{cookiecutter.python_name}}/LICENSE
+++ b/{{cookiecutter.python_name}}/LICENSE
@@ -1,20 +1,21 @@
 BSD 3-Clause License
 
-Copyright (c) {% now 'utc', '%Y' %}, {{ cookiecutter.author_name }} All rights reserved.
+Copyright (c) {% now 'utc', '%Y' %}, {{ cookiecutter.author_name }}
+All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Neither the name of the copyright holder nor the names of its
-  contributors may be used to endorse or promote products derived from
-  this software without specific prior written permission.
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -51,6 +51,7 @@ setup_args = dict(
     author_email=pkg_json["author"]["email"],
     description=pkg_json["description"],
     license=pkg_json["license"],
+    license_file="LICENSE",
     long_description=long_description,
     long_description_content_type="text/markdown",
     packages=setuptools.find_packages(),


### PR DESCRIPTION
This reformats the bullet points of the license file to be in line with the jlab license, the OSI text, and the default GitHub bsd license text (numbered bullet points). It also moves the "All rights reserved" down to its own line, in line with the GitHub bsd license text.

Finally, we add the license_file keyword to setup.py to make sure we are explicitly requiring the license file in the package (rather than relying on the default behavior to include it).
