### PR TITLE
Let cookiecutter render check-release.yml

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,8 +7,5 @@
   "has_settings": "n",
   "has_server_extension": "n",
   "has_binder": "n",
-  "repository": "https://github.com/github_username/{{ cookiecutter.labextension_name }}",
-  "_copy_without_render": [
-    ".github/workflows/check-release.yml"
-  ]
+  "repository": "https://github.com/github_username/{{ cookiecutter.labextension_name }}"
 }

--- a/{{cookiecutter.python_name}}/.github/workflows/check-release.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/check-release.yml
@@ -59,5 +59,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v2
         with:
-          name: {{ cookiecutter.python_name }}-releaser-dist-${{ '{{' }} github.run_number {{ '}}' }}
+          name: {{ cookiecutter.python_name }}-releaser-dist-${{ '{{ github.run_number }}' }}
           path: .jupyter_releaser_checkout/dist

--- a/{{cookiecutter.python_name}}/.github/workflows/check-release.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/check-release.yml
@@ -25,6 +25,8 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '14.x'
+      {# Escape double curly brace #}
+      {% raw %}
       - name: Get pip cache dir
         id: pip-cache
         run: |
@@ -53,8 +55,9 @@ jobs:
         uses: jupyter-server/jupyter_releaser/.github/actions/check-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      {% endraw %}
       - name: Upload Distributions
         uses: actions/upload-artifact@v2
         with:
-          name: {{ cookiecutter.python_name }}-releaser-dist-${{ github.run_number }}
+          name: {{ cookiecutter.python_name }}-releaser-dist-${{ '{{' }} github.run_number {{ '}}' }}
           path: .jupyter_releaser_checkout/dist


### PR DESCRIPTION
The file `check-release.yml` should be rendered by cookiecutter because it uses cookiecutter variable `cookiecutter.python_name` (line 59).

https://github.com/jupyterlab/extension-cookiecutter-ts/blob/6d1b8c628a2a944c6ef4bd23dcce51498b97c3dd/%7B%7Bcookiecutter.python_name%7D%7D/.github/workflows/check-release.yml#L59