### PR TITLE
Install stable JupyterLab on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -257,7 +257,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['has_server_extension']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
-          pip install --pre jupyterlab
+          pip install jupyterlab
           jupyter lab clean --all
           python -m build --sdist
           cd dist


### PR DESCRIPTION
CI is now picking up the latest `4.0.0a16` release which bumped the major version of the JS packages which raises compatibility errors on install.

Example run: https://github.com/jupyterlab/extension-cookiecutter-ts/runs/4446666640?check_suite_focus=true