### PR TITLE
Use same base-setup action for theme test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -250,41 +250,17 @@ jobs:
 
   theme:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # This will be used by the base setup action
+        python-version: ["3.7", "3.10"]
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Install node
-        uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.7"
-          architecture: "x64"
 
-      - name: Setup pip cache
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: pip-3.7-${{ hashFiles('package.json') }}
-          restore-keys: |
-            pip-3.7-
-            pip-
-
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Setup yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            yarn-
+      - name: Base Setup
+        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
In https://github.com/jupyterlab/extension-cookiecutter-ts/pull/196 the CI test for the theme extension was copied from theme cookiecutter and not homogenize with the other test - in particular for the setup. This correct it and should fix #197 