### PR TITLE
WIP: Add testing support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -7,5 +7,6 @@
   "project_short_description": "A JupyterLab extension.",
   "has_settings": "n",
   "has_binder": "n",
+  "has_tests": "n",
   "repository": "https://github.com/github_username/{{ cookiecutter.labextension_name }}"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -39,6 +39,13 @@ if __name__ == "__main__":
         ):
             remove_path(PROJECT_DIRECTORY / f)
 
+        if not "{{ cookiecutter.has_tests }}".lower() == "y":
+            for f in (
+                "{{ cookiecutter.python_name }}/tests",
+                "conftest.py"
+            ):
+                remove_path(PROJECT_DIRECTORY / f)
+
     if not "{{ cookiecutter.has_binder }}".lower().startswith("y"):
         remove_path(PROJECT_DIRECTORY / "binder")
         remove_path(PROJECT_DIRECTORY / ".github/workflows/binder-on-pr.yml")

--- a/{{cookiecutter.python_name}}/MANIFEST.in
+++ b/{{cookiecutter.python_name}}/MANIFEST.in
@@ -1,6 +1,7 @@
 include LICENSE
 include *.md
-include pyproject.toml{% if cookiecutter.kind == "server" %}
+include pyproject.toml{% if cookiecutter.kind.lower() == "server" and cookiecutter.has_tests.lower() == "y" %}
+include conftest.py{% endif %}{% if cookiecutter.kind == "server" %}
 recursive-include jupyter-config *.json{% endif %}
 
 include package.json

--- a/{{cookiecutter.python_name}}/conftest.py
+++ b/{{cookiecutter.python_name}}/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+pytest_plugins = ["jupyter_server.pytest_plugin"]
+
+
+@pytest.fixture
+def jp_server_config(jp_server_config):
+    return {
+        "ServerApp": {
+            "jpserver_extensions": {
+                "{{cookiecutter.python_name}}": True
+            }
+        }
+    }

--- a/{{cookiecutter.python_name}}/setup.py
+++ b/{{cookiecutter.python_name}}/setup.py
@@ -59,6 +59,13 @@ setup_args = dict(
     install_requires=[{% if cookiecutter.kind.lower() == "server" %}
         "jupyter_server>=1.6,<2"
     {% endif %}],
+    extras_require={
+        "test": [{% if cookiecutter.kind.lower() == "server" and cookiecutter.has_tests.lower() == "y" %}
+            {% raw -%}        
+            "pytest", "pytest-tornasync"
+            {%- endraw %}
+        {% endif %}]
+    },
     zip_safe=False,
     include_package_data=True,
     python_requires=">=3.7",

--- a/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/tests/test_handlers.py
+++ b/{{cookiecutter.python_name}}/{{cookiecutter.python_name}}/tests/test_handlers.py
@@ -1,0 +1,11 @@
+import json
+
+
+async def test_handlers(jp_fetch):
+    r = await jp_fetch(
+                "{{ cookiecutter.python_name | replace('_', '-') }}/get_example",
+            )
+    assert r.code == 200
+    assert json.loads(r.body.decode())['data'] is not None
+
+    


### PR DESCRIPTION
Add testing support for both api handlers, and lab extension.

- [x] Add a new option "has_tests"
- [x] Add configuration and setup for python tests
- [x] Add python tests for api handler
- [ ] Add configuration and dependencies for js tests
- [ ] Add unit tests for plugin and handler
- [ ] Update hooks to remove python test setup if "server" is not selected
- [ ] Update hooks to remove js test setup if "has_tests" is not selected