### PR TITLE
Disable noUnusedLocals option

### DIFF
--- a/{{cookiecutter.python_name}}/tsconfig.json
+++ b/{{cookiecutter.python_name}}/tsconfig.json
@@ -10,7 +10,7 @@
     "moduleResolution": "node",
     "noEmitOnError": true,
     "noImplicitAny": true,
-    "noUnusedLocals": true,
+    "noUnusedLocals": false,
     "preserveWatchOutput": true,
     "resolveJsonModule": true,
     "outDir": "lib",


### PR DESCRIPTION
In my opinion it's not the transpiler job to check for unused imports and local variables, it's the linter job. This will make it a bit easier for extension devs to hack around.

cc. @wolfv @psychemedia