### PR TITLE
Fix Build workflow

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Base Setup
-        uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
+      uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
       run: python -m pip install -U jupyterlab~=3.1 check-manifest


### PR DESCRIPTION
Fix an indentation issue in the build workflow noticed after generating a new extension from the cookiecutter recently.