### PR TITLE
fix dev install when there is no global `yarn`

### DIFF
--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -70,6 +70,7 @@ npm = ["jlpm"]
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
 build_cmd = "install:extension"
+npm = ["jlpm"]
 source_dir = "src"
 build_dir = "{{cookiecutter.python_name}}/labextension"
 


### PR DESCRIPTION
I don't have a global `yarn` cmd available in my dev env (in my case, the global `yarn` cmd actually points to apache yarn). With the new hatch build this was causing an error on dev install:

```
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... done
  Installing backend dependencies ... done
  Preparing editable metadata (pyproject.toml) ... error
  error: subprocess-exited-with-error

  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [91 lines of output]
      INFO:hatch_jupyter_builder.utils:Running jupyter-builder
      INFO:hatch_jupyter_builder.utils:Building with hatch_jupyter_builder.npm_builder
      INFO:hatch_jupyter_builder.utils:With kwargs: {'build_cmd': 'install:extension', 'source_dir': 'src', 'build_dir': 'jupyterlab_conda_store/labextension'}
      INFO:hatch_jupyter_builder.utils:Installing build dependencies with npm.  This may take a while...
      INFO:hatch_jupyter_builder.utils:> /usr/local/bin/yarn install
      ERROR: install is not COMMAND nor fully qualified CLASSNAME.
      Usage: yarn [OPTIONS] SUBCOMMAND [SUBCOMMAND OPTIONS]
       or    yarn [OPTIONS] CLASSNAME [CLASSNAME OPTIONS]
...
```

The toml was already set up so that `jlpm` is used instead of `yarn` for regular installs, so I just copied this config over to the dev (ie editable) install. That fixed it