### PR TITLE
fix support for projects with different `python/labextension_name`

### DIFF
--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -47,8 +47,8 @@ Homepage = "{{ cookiecutter.repository }}"
 artifacts = ["{{ cookiecutter.python_name }}/labextension"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"{{ cookiecutter.python_name }}/labextension" = "share/jupyter/labextensions/{{ cookiecutter.python_name }}"
-"install.json" = "share/jupyter/labextensions/{{ cookiecutter.python_name }}/install.json"{% if cookiecutter.kind.lower() == "server" %}
+"{{ cookiecutter.python_name }}/labextension" = "share/jupyter/labextensions/{{ cookiecutter.labextension_name }}"
+"install.json" = "share/jupyter/labextensions/{{ cookiecutter.labextension_name }}/install.json"{% if cookiecutter.kind.lower() == "server" %}
 "jupyter-config/server-config" = "etc/jupyter/jupyter_server_config.d"
 "jupyter-config/nb-config" = "etc/jupyter/jupyter_notebook_config.d"{% endif %}
 


### PR DESCRIPTION
I just ran into another breaking bug in the new hatch toml. This is hidden if the names of the project's python and js packages are exactly the same. However, when I made a project with python package `jupyterlab_x_y` and js package `jupyterlab-x-y` I ran into pathing hell. Ultimately the issue in this case is that the javascript machinery that loads the extension bundle files expect all of the files to be under a dir named after the js package (eg `share/jupyter/labextensions/jupyterlab-x-y`), but the toml template instead places the bundle files under a dir named after the python package (eg `share/jupyter/labextensions/jupyterlab_x_y`). This leads to a fatal NOT-FOUND error on attempted extension bundle load. This PR fixes that