### PR TITLE
Fix Template To Enable Pip install Without Failure

### DIFF
--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -58,7 +58,7 @@ dependencies = ["hatch-jupyter-builder>=0.5"]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [{% if cookiecutter.kind.lower() != "theme" %}
     "{{ cookiecutter.python_name }}/labextension/static/style.js",{% endif %}
-    "{{ cookiecutter.python_name }}//labextension/package.json",
+    "{{ cookiecutter.python_name }}/labextension/package.json",
 ]
 skip-if-exists = ["{{ cookiecutter.python_name }}/labextension/static/style.js"]
 


### PR DESCRIPTION
When I tried using this template, I noticed that on line 61, there is an extra backslash. This was causing the `pip install -ve .` to fail. 

How to reproduce:

# create a new boilerplate project
```
cookiecutter https://github.com/jupyterlab/extension-cookiecutter-ts 

# add this inside a Docker image
pip install -ve .
jupyter labextension build
```

Expected failure:
![FailurePart1](https://user-images.githubusercontent.com/17467397/193661083-93a17d44-42f9-4bb7-a51a-240947090c2e.PNG)
![FailurePart2](https://user-images.githubusercontent.com/17467397/193661096-8d01ace0-5dac-4997-b350-0ed4a164c51c.PNG)
