### PR TITLE
[4.0] Update the cookiecutter for JupyterLab 4 and Notebook 7

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U cookiecutter jupyterlab~=3.1
+        run: python -m pip install -U cookiecutter jupyterlab>=4.0.0a29,<5
 
       - name: Create the extension
         run: |

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U cookiecutter jupyterlab>=4.0.0a29,<5
+        run: python -m pip install -U cookiecutter "jupyterlab>=4.0.0a29,<5"
 
       - name: Create the extension
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
-          python -m jupyterlab.browser_check --no-chrome-test
+          python -m jupyterlab.browser_check
 
   theme:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
-          python -m jupyterlab.browser_check --no-chrome-test
+          python -m jupyterlab.browser_check --no-browser-test
 
   theme:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -290,7 +290,7 @@ jobs:
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
-          python -m jupyterlab.browser_check
+          python -m jupyterlab.browser_check --no-chrome-test
 
   theme:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json, os; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['labextension_name']=os.getenv('NAME'); cookiecutter('.', extra_context=d, no_input=True)"
           pushd ${PYNAME}
-          python -m pip install jupyterlab>=4.0.0a29,<5
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm stylelint-config-prettier-check
           jlpm lint:check
@@ -81,7 +81,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['test']='n'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install jupyterlab>=4.0.0a29,<5
+          pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm lint:check
           pip install -e .
@@ -120,7 +120,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['has_settings']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install jupyterlab>=4.0.0a29,<5
+          pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           # It is not easily possible to get this version compatible with linter rules
           jlpm lint
@@ -164,7 +164,7 @@ jobs:
           cd myextension
           cat pyproject.toml
           pip install .
-          pip install jupyterlab>=4.0.0a29,<5
+          pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm lint:check
 
@@ -189,7 +189,7 @@ jobs:
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
           python -m pip install -e .[test]
-          python -m pip install jupyterlab>=4.0.0a29,<5
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jupyter labextension develop . --overwrite
           jupyter server extension enable myextension
 
@@ -223,7 +223,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
-          python -m pip install jupyterlab>=4.0.0a29,<5
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jupyter lab clean --all
           python -m build --sdist
           cd dist
@@ -286,7 +286,7 @@ jobs:
           sudo rm -rf $(which node)
 
           python -m pip install myextension.tar.gz
-          python -m pip install jupyterlab>=4.0.0a29,<5
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
@@ -316,7 +316,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='theme'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd mytheme
-          python -m pip install jupyterlab>=4.0.0a29,<5
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm lint:check
           python -m pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json, os; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['labextension_name']=os.getenv('NAME'); cookiecutter('.', extra_context=d, no_input=True)"
           pushd ${PYNAME}
-          python -m pip install jupyterlab
+          python -m pip install jupyterlab>=4.0.0a29,<5
           jlpm
           jlpm stylelint-config-prettier-check
           jlpm lint:check
@@ -81,7 +81,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['test']='n'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install jupyterlab
+          pip install jupyterlab>=4.0.0a29,<5
           jlpm
           jlpm lint:check
           pip install -e .
@@ -120,7 +120,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['has_settings']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install jupyterlab
+          pip install jupyterlab>=4.0.0a29,<5
           jlpm
           # It is not easily possible to get this version compatible with linter rules
           jlpm lint
@@ -164,7 +164,7 @@ jobs:
           cd myextension
           cat pyproject.toml
           pip install .
-          pip install jupyterlab
+          pip install jupyterlab>=4.0.0a29,<5
           jlpm
           jlpm lint:check
 
@@ -189,7 +189,7 @@ jobs:
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
           python -m pip install -e .[test]
-          python -m pip install jupyterlab
+          python -m pip install jupyterlab>=4.0.0a29,<5
           jupyter labextension develop . --overwrite
           jupyter server extension enable myextension
 
@@ -223,7 +223,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
-          python -m pip install jupyterlab
+          python -m pip install jupyterlab>=4.0.0a29,<5
           jupyter lab clean --all
           python -m build --sdist
           cd dist
@@ -286,7 +286,7 @@ jobs:
           sudo rm -rf $(which node)
 
           python -m pip install myextension.tar.gz
-          python -m pip install jupyterlab
+          python -m pip install jupyterlab>=4.0.0a29,<5
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
@@ -316,7 +316,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='theme'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd mytheme
-          python -m pip install jupyterlab
+          python -m pip install jupyterlab>=4.0.0a29,<5
           jlpm
           jlpm lint:check
           python -m pip install -e .

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
-      run: python -m pip install -U jupyterlab>=4.0.0a29,<5
+      run: python -m pip install -U "jupyterlab>=4.0.0a29,<5"
 
     - name: Lint the extension
       run: |

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
 {% endif %}
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "{{ cookiecutter.labextension_name }}.*OK"
-        python -m jupyterlab.browser_check
+        python -m jupyterlab.browser_check --no-chrome-test
 {% if cookiecutter.test.lower().startswith('y') %}
   integration-tests:
     name: Integration tests

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
 {% endif %}
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "{{ cookiecutter.labextension_name }}.*OK"
-        python -m jupyterlab.browser_check --no-chrome-test
+        python -m jupyterlab.browser_check --no-browser-test
 {% if cookiecutter.test.lower().startswith('y') %}
   integration-tests:
     name: Integration tests

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
 {% endif %}
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "{{ cookiecutter.labextension_name }}.*OK"
-        python -m jupyterlab.browser_check --no-chrome-test
+        python -m jupyterlab.browser_check
 {% if cookiecutter.test.lower().startswith('y') %}
   integration-tests:
     name: Integration tests

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
-      run: python -m pip install -U jupyterlab~=3.1
+      run: python -m pip install -U jupyterlab>=4.0.0a29,<5
 
     - name: Lint the extension
       run: |
@@ -81,7 +81,7 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab~=3.1" {{ cookiecutter.python_name }}*.whl
+        pip install "jupyterlab>=4.0.0a29,<5" {{ cookiecutter.python_name }}*.whl
 
 {% if cookiecutter.kind.lower() == 'server' %}
         jupyter server extension list
@@ -114,7 +114,7 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab~=3.1" {{ cookiecutter.python_name }}*.whl
+        python -m pip install "jupyterlab>=4.0.0a29,<5" {{ cookiecutter.python_name }}*.whl
 
     - name: Install dependencies
       working-directory: ui-tests

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -12,7 +12,7 @@ for the frontend extension.
 {% endif %}
 ## Requirements
 
-- JupyterLab >= 3.0
+- JupyterLab >= 4.0.0a29
 
 ## Install
 

--- a/{{cookiecutter.python_name}}/binder/environment.yml
+++ b/{{cookiecutter.python_name}}/binder/environment.yml
@@ -11,7 +11,7 @@ channels:
 
 dependencies:
   # runtime dependencies
-  - python >=3.8,<3.9.0a0
+  - python >=3.10,<3.11.0a0
   - jupyterlab >=4.0.0a29,<5
   # labextension build dependencies
   - nodejs >=16,<17

--- a/{{cookiecutter.python_name}}/binder/environment.yml
+++ b/{{cookiecutter.python_name}}/binder/environment.yml
@@ -12,7 +12,7 @@ channels:
 dependencies:
   # runtime dependencies
   - python >=3.8,<3.9.0a0
-  - jupyterlab >=3,<4.0.0a0
+  - jupyterlab >=4.0.0a29,<5
   # labextension build dependencies
   - nodejs >=14,<15
   - pip

--- a/{{cookiecutter.python_name}}/binder/environment.yml
+++ b/{{cookiecutter.python_name}}/binder/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - python >=3.8,<3.9.0a0
   - jupyterlab >=4.0.0a29,<5
   # labextension build dependencies
-  - nodejs >=14,<15
+  - nodejs >=16,<17
   - pip
   - wheel
   # additional packages for demos

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -55,18 +55,18 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyterlab/application": "^3.1.0"{% if cookiecutter.kind.lower() == 'theme' %},
-    "@jupyterlab/apputils": "^3.1.0"{% endif %}{% if cookiecutter.has_settings.lower().startswith('y') %},
-    "@jupyterlab/settingregistry": "^3.1.0"{% endif %}{% if cookiecutter.kind.lower() == 'server' %},
-    "@jupyterlab/coreutils": "^5.1.0",
-    "@jupyterlab/services": "^6.1.0"
+    "@jupyterlab/application": "^4.0.0-alpha.14"{% if cookiecutter.kind.lower() == 'theme' %},
+    "@jupyterlab/apputils": "^4.0.0-alpha.14"{% endif %}{% if cookiecutter.has_settings.lower().startswith('y') %},
+    "@jupyterlab/settingregistry": "^4.0.0-alpha.14"{% endif %}{% if cookiecutter.kind.lower() == 'server' %},
+    "@jupyterlab/coreutils": "^6.0.0-alpha.14",
+    "@jupyterlab/services": "^7.0.0-alpha.14"
 {% endif %}
   },
   "devDependencies": {
     {% if cookiecutter.test.lower().startswith('y') %}"@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
-    {% endif %}"@jupyterlab/builder": "^3.1.0",{% if cookiecutter.test.lower().startswith('y') %}
-    "@jupyterlab/testutils": "^3.0.0",
+    {% endif %}"@jupyterlab/builder": "^4.0.0-alpha.14",{% if cookiecutter.test.lower().startswith('y') %}
+    "@jupyterlab/testutils": "47.0.0-alpha.14",
     "@types/jest": "^26.0.0",{% endif %}
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -113,7 +113,7 @@
   "jupyter-releaser": {
     "hooks": {
       "before-build-npm": [
-        "python -m pip install jupyterlab~=3.1",
+        "python -m pip install jupyterlab>=4.0.0a29,<5",
         "jlpm"
       ],
       "before-build-python": [

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -66,7 +66,7 @@
     {% if cookiecutter.test.lower().startswith('y') %}"@babel/core": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     {% endif %}"@jupyterlab/builder": "^4.0.0-alpha.14",{% if cookiecutter.test.lower().startswith('y') %}
-    "@jupyterlab/testutils": "47.0.0-alpha.14",
+    "@jupyterlab/testutils": "^4.0.0-alpha.14",
     "@types/jest": "^26.0.0",{% endif %}
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.3.1", "jupyterlab>=3.4.7,<4.0.0", "hatch-nodejs-version"]
+requires = ["hatchling>=1.3.1", "jupyterlab>=4.0.0a29,<5", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]

--- a/{{cookiecutter.python_name}}/tsconfig.json
+++ b/{{cookiecutter.python_name}}/tsconfig.json
@@ -17,7 +17,7 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": true,
-    "target": "es2017",
+    "target": "ES2018",
     "types": [{% if cookiecutter.test.lower().startswith('y') %}"jest"{% endif %}]
   },
   "include": ["src/*"]

--- a/{{cookiecutter.python_name}}/ui-tests/package.json
+++ b/{{cookiecutter.python_name}}/ui-tests/package.json
@@ -8,6 +8,6 @@
     "test": "jlpm playwright test"
   },
   "devDependencies": {
-    "@jupyterlab/galata": "^4.3.0"
+    "@jupyterlab/galata": "^5.0.0-alpha.14"
   }
 }


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/extension-cookiecutter-ts/issues/231

The motivation is to be able to start creating extensions for JupyterLab 4 and Notebook 7 directly using this cookiecutter:

```
cookiecutter https://github.com/jupyterlab/extension-cookiecutter-ts --checkout 4.0
```