### PR TITLE
Improve [test] template conditioning

### DIFF
--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -61,7 +61,7 @@ The `jlpm` command is JupyterLab's pinned version of
 # Clone the repo to your local environment
 # Change directory to the {{ cookiecutter.python_name }} directory
 # Install package in development mode
-pip install -e ".{% if cookiecutter.kind.lower() == 'server' %}[test]{% endif %}"
+pip install -e ".[test]"
 # Link your development version of the extension with JupyterLab
 jupyter labextension develop . --overwrite{% if cookiecutter.kind.lower() == 'server' %}
 # Server extension must be manually installed in develop mode

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -61,7 +61,7 @@ The `jlpm` command is JupyterLab's pinned version of
 # Clone the repo to your local environment
 # Change directory to the {{ cookiecutter.python_name }} directory
 # Install package in development mode
-pip install -e ".[test]"
+pip install -e ".{% if cookiecutter.test.lower().startswith('y') and cookiecutter.kind.lower() == 'server' %}[test]{% endif %}"
 # Link your development version of the extension with JupyterLab
 jupyter labextension develop . --overwrite{% if cookiecutter.kind.lower() == 'server' %}
 # Server extension must be manually installed in develop mode

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -109,6 +109,8 @@ Install test dependencies (needed only once):
 
 ```sh
 pip install -e ".[test]"
+# Each time you install the Python package, you need to restore the front-end extension link
+jupyter labextension develop . --overwrite
 ```
 
 To execute them, run:

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -3,6 +3,7 @@
 [![Github Actions Status]({{ cookiecutter.repository }}/workflows/Build/badge.svg)]({{ cookiecutter.repository }}/actions/workflows/build.yml)
 {%- if cookiecutter.has_binder.lower().startswith('y') -%}
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/{{ cookiecutter.repository|replace("https://github.com/", "") }}/main?urlpath=lab)
+
 {%- endif %}
 {{ cookiecutter.project_short_description }}
 {% if cookiecutter.kind.lower() == 'server' %}
@@ -60,7 +61,7 @@ The `jlpm` command is JupyterLab's pinned version of
 # Clone the repo to your local environment
 # Change directory to the {{ cookiecutter.python_name }} directory
 # Install package in development mode
-pip install -e .
+pip install -e ".{% if cookiecutter.kind.lower() == 'server' %}[test]{% endif %}"
 # Link your development version of the extension with JupyterLab
 jupyter labextension develop . --overwrite{% if cookiecutter.kind.lower() == 'server' %}
 # Server extension must be manually installed in develop mode

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -26,16 +26,16 @@ dependencies = [{% if cookiecutter.kind.lower() == "server" %}
     "jupyter_server>=1.21,<3"{% endif %}
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
-
+{% if cookiecutter.test.lower().startswith('y') and cookiecutter.kind.lower() == 'server' %}
 [project.optional-dependencies]
-test = [{% if cookiecutter.test.lower().startswith('y') %}
+test = [
     "coverage",
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
-    "pytest-jupyter[server]>=0.6.0"{% endif %}
+    "pytest-jupyter[server]>=0.6.0"
 ]
-
+{% endif %}
 [tool.hatch.version]
 source = "nodejs"
 


### PR DESCRIPTION
Add the `[test]` dep group only when needed.
Add the `[test]` group to the pip install command when needed
Add the linking command to avoid confusion after only triggering `pip install`