### PR TITLE
Relax `.prettierignore` to format the root `package.json` as well

### DIFF
--- a/{{cookiecutter.python_name}}/.prettierignore
+++ b/{{cookiecutter.python_name}}/.prettierignore
@@ -2,4 +2,5 @@ node_modules
 **/node_modules
 **/lib
 **/package.json
+!/package.json
 {{cookiecutter.python_name}}

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -95,14 +95,14 @@
   },
   "jupyterlab": { {% if cookiecutter.kind.lower() == 'server' %}
     "discovery": {
-        "server": {
-          "managers": [
-            "pip"
-          ],
-          "base": {
-            "name": "{{ cookiecutter.python_name }}"
-          }
+      "server": {
+        "managers": [
+          "pip"
+        ],
+        "base": {
+          "name": "{{ cookiecutter.python_name }}"
         }
+      }
     },{% endif %}
     "extension": true,
     "outputDir": "{{cookiecutter.python_name}}/labextension"{% if cookiecutter.has_settings.lower().startswith('y') %},

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -22,8 +22,8 @@
     "schema/*.json"{% endif %}
   ],
   "main": "lib/index.js",
-  "types": "lib/index.d.ts",
-  {% if cookiecutter.kind != 'theme' %}"style": "style/index.css",{% endif %}
+  "types": "lib/index.d.ts",{% if cookiecutter.kind != 'theme' %}
+  "style": "style/index.css",{% endif %}
   "repository": {
     "type": "git",
     "url": "{{ cookiecutter.repository }}.git"

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -89,7 +89,8 @@
     "style/*.css"{% if cookiecutter.kind.lower() != 'theme' %},
     "style/index.js"
   ],
-  "styleModule": "style/index.js",{% else %}],{% endif %}
+  "styleModule": "style/index.js",{% else %}
+  ],{% endif %}
   "publishConfig": {
     "access": "public"
   },

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -93,7 +93,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "jupyterlab": { {% if cookiecutter.kind.lower() == 'server' %}
+  "jupyterlab": { {%- if cookiecutter.kind.lower() == 'server' %}
     "discovery": {
       "server": {
         "managers": [

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -59,8 +59,7 @@
     "@jupyterlab/apputils": "^3.1.0"{% endif %}{% if cookiecutter.has_settings.lower().startswith('y') %},
     "@jupyterlab/settingregistry": "^3.1.0"{% endif %}{% if cookiecutter.kind.lower() == 'server' %},
     "@jupyterlab/coreutils": "^5.1.0",
-    "@jupyterlab/services": "^6.1.0"
-{% endif %}
+    "@jupyterlab/services": "^6.1.0"{% endif %}
   },
   "devDependencies": {
     {% if cookiecutter.test.lower().startswith('y') %}"@babel/core": "^7.0.0",


### PR DESCRIPTION
Another possibility is to remove the `**/package.json` line, as the other patterns cover most cases, if I'm correct.