### PR TITLE
Add `yarn-error.log` to `.gitignore`

### DIFF
--- a/{{cookiecutter.python_name}}/.gitignore
+++ b/{{cookiecutter.python_name}}/.gitignore
@@ -1,6 +1,7 @@
 *.bundle.*
 lib/
 node_modules/
+yarn-error.log
 .eslintcache
 .stylelintcache
 *.egg-info/

--- a/{{cookiecutter.python_name}}/.gitignore
+++ b/{{cookiecutter.python_name}}/.gitignore
@@ -1,7 +1,7 @@
 *.bundle.*
 lib/
 node_modules/
-yarn-error.log
+*.log
 .eslintcache
 .stylelintcache
 *.egg-info/


### PR DESCRIPTION
If an error occurs when running a script through `jlpm` (due to a missing comma between scripts), for example, Yarn generates an error log file. So, with this addition, this file is also ignored.