### PR TITLE
Add `_version.py` to one of the `clean` scripts

### DIFF
--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -37,7 +37,7 @@
     "clean": "jlpm clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:lintcache": "rimraf .eslintcache .stylelintcache",
-    "clean:labextension": "rimraf {{ cookiecutter.python_name }}/labextension",
+    "clean:labextension": "rimraf {{ cookiecutter.python_name }}/labextension {{ cookiecutter.python_name }}/_version.py",
     "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
     "eslint": "jlpm eslint:check --fix",
     "eslint:check": "eslint . --cache --ext .ts,.tsx",


### PR DESCRIPTION
Since the `_version.py` file is also automatically generated, it could also be cleaned by the `clean:labextension` script (or another one you deem more appropriate).