### PR TITLE
Add `ignore` for `check-wheel-contents`

### DIFF
--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -82,4 +82,4 @@ before-build-npm = ["python -m pip install jupyterlab~=3.1", "jlpm", "jlpm build
 before-build-python = ["jlpm clean:all"]
 
 [tool.check-wheel-contents]
-ignore = ["W002", "W004"]
+ignore = ["W002"]

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -80,3 +80,6 @@ version_cmd = "hatch version"
 [tool.jupyter-releaser.hooks]
 before-build-npm = ["python -m pip install jupyterlab~=3.1", "jlpm", "jlpm build:prod"]
 before-build-python = ["jlpm clean:all"]
+
+[tool.check-wheel-contents]
+ignore = ["W002", "W004"]


### PR DESCRIPTION
Without these ignores the `check_release` check will likely fail for extensions.

Based on the discussions in https://github.com/jupyterlab/jupyterlab/pull/13654