### PR TITLE
Updated default build to generate source maps

### DIFF
--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -30,10 +30,11 @@
   },
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",
-    "build:prod": "jlpm clean && jlpm build:lib && jlpm build:labextension",
+    "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
     "build:labextension": "jupyter labextension build .",
     "build:labextension:dev": "jupyter labextension build --development True .",
-    "build:lib": "tsc",
+    "build:lib": "tsc --sourceMap",
+    "build:lib:prod": "tsc",
     "clean": "jlpm clean:lib",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:lintcache": "rimraf .eslintcache .stylelintcache",


### PR DESCRIPTION
Complementary PR to https://github.com/jupyterlab/jupyterlab/pull/13765. This will update the default dev build to generate source maps for typescript source code. Added a new build target "build:lib:prod" to compile typescript without source maps. 