### PR TITLE
Fix wrong version specifier

### DIFF
--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -79,7 +79,7 @@ version_cmd = "hatch version"
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
-    "python -m pip install jupyterlab~=4.0.0a29",
+    "python -m pip install 'jupyterlab>=4.0.0a29,<5'",
     "jlpm",
     "jlpm build:prod"
 ]

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -79,7 +79,7 @@ version_cmd = "hatch version"
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
-    "python -m pip install jupyterlab>=4.0.0a29,<5",
+    "python -m pip install jupyterlab~=4.0.0a29",
     "jlpm",
     "jlpm build:prod"
 ]


### PR DESCRIPTION
`python -m pip install jupyterlab>=4.0.0a29,<5` is not working and results this error during jupyter_releaser release action.
```
Running hooks for before-build-npm
/bin/sh: 1: cannot open 5: No such file
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.10.9/x64/bin/jupyter-releaser", line 8, in <module>
    sys.exit(main())
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.10.9/x64/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/cli.py", line 119, in invoke
    util.run(hook)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/util.py", line 91, in run
    raise e
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/util.py", line 83, in run
    process = tee(cmd, **kwargs)
  File "/home/runner/work/jupyter_releaser/jupyter_releaser/jupyter_releaser/tee.py", line 159, in run
    raise subprocess.CalledProcessError(
subprocess.CalledProcessError: Command 'python -m pip install jupyterlab>=4.0.0a29,<5' returned non-zero exit status 2.
```

