### PR TITLE
Update to JupyterLab 4.0.0a34

### DIFF
--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U cookiecutter "jupyterlab>=4.0.0a29,<5"
+        run: python -m pip install -U cookiecutter "jupyterlab>=4.0.0a34,<5"
 
       - name: Create the extension
         run: |

--- a/.github/workflows/check-tests.yml
+++ b/.github/workflows/check-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U cookiecutter "jupyterlab>=4.0.0a33,<5"
+        run: python -m pip install -U cookiecutter "jupyterlab>=4.0.0a29,<5"
 
       - name: Create the extension
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json, os; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['labextension_name']=os.getenv('NAME'); cookiecutter('.', extra_context=d, no_input=True)"
           pushd ${PYNAME}
-          python -m pip install "jupyterlab>=4.0.0a33,<5"
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm stylelint-config-prettier-check
           jlpm lint:check
@@ -81,7 +81,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['test']='n'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install "jupyterlab>=4.0.0a33,<5"
+          pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm lint:check
           pip install -e .
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         # This will be used by the base setup action
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.7", "3.11"]
 
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['has_settings']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install "jupyterlab>=4.0.0a33,<5"
+          pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           # It is not easily possible to get this version compatible with linter rules
           jlpm lint
@@ -144,7 +144,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # This will be used by the base setup action
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.7", "3.11"]
 
     steps:
       - name: Checkout
@@ -164,7 +164,7 @@ jobs:
           cd myextension
           cat pyproject.toml
           pip install .
-          pip install "jupyterlab>=4.0.0a33,<5"
+          pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm lint:check
 
@@ -189,7 +189,7 @@ jobs:
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
           python -m pip install -e .[test]
-          python -m pip install "jupyterlab>=4.0.0a33,<5"
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jupyter labextension develop . --overwrite
           jupyter server extension enable myextension
 
@@ -223,7 +223,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
-          python -m pip install "jupyterlab>=4.0.0a33,<5"
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jupyter lab clean --all
           python -m build
           cd dist
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.7", "3.11"]
 
     steps:
       - name: Checkout
@@ -289,7 +289,7 @@ jobs:
           sudo rm -rf $(which node)
 
           python -m pip install myextension.tar.gz
-          python -m pip install "jupyterlab>=4.0.0a33,<5"
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
@@ -300,7 +300,7 @@ jobs:
     strategy:
       matrix:
         # This will be used by the base setup action
-        python-version: ["3.8", "3.11"]
+        python-version: ["3.7", "3.11"]
 
     steps:
       - name: Checkout
@@ -319,7 +319,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='theme'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd mytheme
-          python -m pip install "jupyterlab>=4.0.0a33,<5"
+          python -m pip install "jupyterlab>=4.0.0a29,<5"
           jlpm
           jlpm lint:check
           python -m pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json, os; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['labextension_name']=os.getenv('NAME'); cookiecutter('.', extra_context=d, no_input=True)"
           pushd ${PYNAME}
-          python -m pip install "jupyterlab>=4.0.0a29,<5"
+          python -m pip install "jupyterlab>=4.0.0a34,<5"
           jlpm
           jlpm stylelint-config-prettier-check
           jlpm lint:check
@@ -81,7 +81,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['test']='n'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install "jupyterlab>=4.0.0a29,<5"
+          pip install "jupyterlab>=4.0.0a34,<5"
           jlpm
           jlpm lint:check
           pip install -e .
@@ -120,7 +120,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']=d['kind'][0]; d['has_settings']='y'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd myextension
-          pip install "jupyterlab>=4.0.0a29,<5"
+          pip install "jupyterlab>=4.0.0a34,<5"
           jlpm
           # It is not easily possible to get this version compatible with linter rules
           jlpm lint
@@ -164,7 +164,7 @@ jobs:
           cd myextension
           cat pyproject.toml
           pip install .
-          pip install "jupyterlab>=4.0.0a29,<5"
+          pip install "jupyterlab>=4.0.0a34,<5"
           jlpm
           jlpm lint:check
 
@@ -189,7 +189,7 @@ jobs:
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
           python -m pip install -e .[test]
-          python -m pip install "jupyterlab>=4.0.0a29,<5"
+          python -m pip install "jupyterlab>=4.0.0a34,<5"
           jupyter labextension develop . --overwrite
           jupyter server extension enable myextension
 
@@ -223,7 +223,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='server'; cookiecutter('.', extra_context=d, no_input=True)"
           cd myextension
-          python -m pip install "jupyterlab>=4.0.0a29,<5"
+          python -m pip install "jupyterlab>=4.0.0a34,<5"
           jupyter lab clean --all
           python -m build
           cd dist
@@ -289,7 +289,7 @@ jobs:
           sudo rm -rf $(which node)
 
           python -m pip install myextension.tar.gz
-          python -m pip install "jupyterlab>=4.0.0a29,<5"
+          python -m pip install "jupyterlab>=4.0.0a34,<5"
           jupyter labextension list 2>&1 | grep -ie "myextension.*OK"
           jupyter server extension list
           jupyter server extension list 2>&1 | grep -ie "myextension.*OK"
@@ -319,7 +319,7 @@ jobs:
           # Trick to use custom parameters
           python -c "from cookiecutter.main import cookiecutter; import json; f=open('cookiecutter.json'); d=json.load(f); f.close(); d['kind']='theme'; cookiecutter('.', extra_context=d, no_input=True)"
           pushd mytheme
-          python -m pip install "jupyterlab>=4.0.0a29,<5"
+          python -m pip install "jupyterlab>=4.0.0a34,<5"
           jlpm
           jlpm lint:check
           python -m pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
     strategy:
       matrix:
         # This will be used by the base setup action
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     steps:
       - name: Checkout
@@ -144,7 +144,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # This will be used by the base setup action
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     steps:
       - name: Checkout
@@ -260,7 +260,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     steps:
       - name: Checkout
@@ -300,7 +300,7 @@ jobs:
     strategy:
       matrix:
         # This will be used by the base setup action
-        python-version: ["3.7", "3.11"]
+        python-version: ["3.8", "3.11"]
 
     steps:
       - name: Checkout

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0a29,<5"
+      run: python -m pip install -U "jupyterlab>=4.0.0a34,<5"
 
     - name: Lint the extension
       run: |
@@ -81,7 +81,7 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0a29,<5" {{ cookiecutter.python_name }}*.whl
+        pip install "jupyterlab>=4.0.0a34,<5" {{ cookiecutter.python_name }}*.whl
 
 {% if cookiecutter.kind.lower() == 'server' %}
         jupyter server extension list
@@ -114,7 +114,7 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab>=4.0.0a29,<5" {{ cookiecutter.python_name }}*.whl
+        python -m pip install "jupyterlab>=4.0.0a34,<5" {{ cookiecutter.python_name }}*.whl
 
     - name: Install dependencies
       working-directory: ui-tests

--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
     - name: Install dependencies
-      run: python -m pip install -U "jupyterlab>=4.0.0a33,<5"
+      run: python -m pip install -U "jupyterlab>=4.0.0a29,<5"
 
     - name: Lint the extension
       run: |
@@ -81,7 +81,7 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0a33,<5" {{ cookiecutter.python_name }}*.whl
+        pip install "jupyterlab>=4.0.0a29,<5" {{ cookiecutter.python_name }}*.whl
 
 {% if cookiecutter.kind.lower() == 'server' %}
         jupyter server extension list
@@ -114,7 +114,7 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab>=4.0.0a33,<5" {{ cookiecutter.python_name }}*.whl
+        python -m pip install "jupyterlab>=4.0.0a29,<5" {{ cookiecutter.python_name }}*.whl
 
     - name: Install dependencies
       working-directory: ui-tests

--- a/{{cookiecutter.python_name}}/.github/workflows/update-integration-tests.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/update-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlab>=4.0.0a33,<5"
+        run: python -m pip install -U "jupyterlab>=4.0.0a29,<5"
 
       - name: Install extension
         run: |

--- a/{{cookiecutter.python_name}}/.github/workflows/update-integration-tests.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/update-integration-tests.yml
@@ -33,7 +33,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Install dependencies
-        run: python -m pip install -U "jupyterlab>=4.0.0a29,<5"
+        run: python -m pip install -U "jupyterlab>=4.0.0a34,<5"
 
       - name: Install extension
         run: |

--- a/{{cookiecutter.python_name}}/README.md
+++ b/{{cookiecutter.python_name}}/README.md
@@ -13,7 +13,7 @@ for the frontend extension.
 {% endif %}
 ## Requirements
 
-- JupyterLab >= 4.0.0a33
+- JupyterLab >= 4.0.0a29
 
 ## Install
 

--- a/{{cookiecutter.python_name}}/binder/environment.yml
+++ b/{{cookiecutter.python_name}}/binder/environment.yml
@@ -12,7 +12,7 @@ channels:
 dependencies:
   # runtime dependencies
   - python >=3.10,<3.11.0a0
-  - jupyterlab >=4.0.0a33,<5
+  - jupyterlab >=4.0.0a29,<5
   # labextension build dependencies
   - nodejs >=18,<19
   - pip

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -56,15 +56,15 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyterlab/application": "^4.0.0-alpha.17"{% if cookiecutter.kind.lower() == 'theme' %},
-    "@jupyterlab/apputils": "^4.0.0-alpha.17"{% endif %}{% if cookiecutter.has_settings.lower().startswith('y') %},
-    "@jupyterlab/settingregistry": "^4.0.0-alpha.17"{% endif %}{% if cookiecutter.kind.lower() == 'server' %},
-    "@jupyterlab/coreutils": "^6.0.0-alpha.17",
-    "@jupyterlab/services": "^7.0.0-alpha.17"{% endif %}
+    "@jupyterlab/application": "^4.0.0-alpha.19"{% if cookiecutter.kind.lower() == 'theme' %},
+    "@jupyterlab/apputils": "^4.0.0-alpha.19"{% endif %}{% if cookiecutter.has_settings.lower().startswith('y') %},
+    "@jupyterlab/settingregistry": "^4.0.0-alpha.19"{% endif %}{% if cookiecutter.kind.lower() == 'server' %},
+    "@jupyterlab/coreutils": "^6.0.0-alpha.19",
+    "@jupyterlab/services": "^7.0.0-alpha.19"{% endif %}
   },
   "devDependencies": {
-    "@jupyterlab/builder": "^4.0.0-alpha.17",{% if cookiecutter.test.lower().startswith('y') %}
-    "@jupyterlab/testutils": "^4.0.0-alpha.17",
+    "@jupyterlab/builder": "^4.0.0-alpha.19",{% if cookiecutter.test.lower().startswith('y') %}
+    "@jupyterlab/testutils": "^4.0.0-alpha.19",
     "@types/jest": "^29.2.0",{% endif %}
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",

--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -66,7 +66,6 @@
     "@jupyterlab/builder": "^4.0.0-alpha.17",{% if cookiecutter.test.lower().startswith('y') %}
     "@jupyterlab/testutils": "^4.0.0-alpha.17",
     "@types/jest": "^29.2.0",{% endif %}
-    "@types/react": "^18.0.26",
     "@typescript-eslint/eslint-plugin": "^4.8.1",
     "@typescript-eslint/parser": "^4.8.1",
     "eslint": "^7.14.0",

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab>=4.0.0a29,<5", "hatch-nodejs-version"]
+requires = ["hatchling>=1.4.0", "jupyterlab>=4.0.0a34,<5", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
@@ -79,7 +79,7 @@ version_cmd = "hatch version"
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
-    "python -m pip install 'jupyterlab>=4.0.0a29,<5'",
+    "python -m pip install 'jupyterlab>=4.0.0a34,<5'",
     "jlpm",
     "jlpm build:prod"
 ]

--- a/{{cookiecutter.python_name}}/pyproject.toml
+++ b/{{cookiecutter.python_name}}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.4.0", "jupyterlab>=4.0.0a33,<5", "hatch-nodejs-version"]
+requires = ["hatchling>=1.4.0", "jupyterlab>=4.0.0a29,<5", "hatch-nodejs-version"]
 build-backend = "hatchling.build"
 
 [project]
@@ -79,7 +79,7 @@ version_cmd = "hatch version"
 
 [tool.jupyter-releaser.hooks]
 before-build-npm = [
-    "python -m pip install 'jupyterlab>=4.0.0a33,<5'",
+    "python -m pip install 'jupyterlab>=4.0.0a29,<5'",
     "jlpm",
     "jlpm build:prod"
 ]

--- a/{{cookiecutter.python_name}}/ui-tests/jupyter_server_test_config.py
+++ b/{{cookiecutter.python_name}}/ui-tests/jupyter_server_test_config.py
@@ -4,17 +4,9 @@
 opens the server to the world and provide access to JupyterLab
 JavaScript objects through the global window variable.
 """
-from tempfile import mkdtemp
+from jupyterlab.galata import configure_jupyter_server
 
-c.ServerApp.port = 8888
-c.ServerApp.port_retries = 0
-c.ServerApp.open_browser = False
-
-c.ServerApp.root_dir = mkdtemp(prefix='galata-test-')
-c.ServerApp.token = ""
-c.ServerApp.password = ""
-c.ServerApp.disable_check_xsrf = True
-c.LabApp.expose_app_in_browser = True
+configure_jupyter_server(c)
 
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"

--- a/{{cookiecutter.python_name}}/ui-tests/jupyter_server_test_config.py
+++ b/{{cookiecutter.python_name}}/ui-tests/jupyter_server_test_config.py
@@ -7,6 +7,8 @@ JavaScript objects through the global window variable.
 from jupyterlab.galata import configure_jupyter_server
 
 configure_jupyter_server(c)
+# FIXME upstream
+c.LabApp.dev_mode = False
 
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"


### PR DESCRIPTION
Reverts jupyterlab/extension-cookiecutter-ts#286 as it should not be needed any longer following https://github.com/jupyterlab/jupyterlab/pull/13981