### PR TITLE
Add ui-tests as workspace

### DIFF
--- a/{{cookiecutter.python_name}}/package.json
+++ b/{{cookiecutter.python_name}}/package.json
@@ -27,7 +27,10 @@
   "repository": {
     "type": "git",
     "url": "{{ cookiecutter.repository }}.git"
-  },
+  },{% if cookiecutter.test.lower().startswith('y') %}
+  "workspaces": [
+    "ui-tests"
+  ],{% endif %}
   "scripts": {
     "build": "jlpm build:lib && jlpm build:labextension:dev",
     "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",


### PR DESCRIPTION
Using Yarn3, trying to install the ui-tests dependencies requires the ui-tests package to be declared as a workspace of the extension.