### PR TITLE
Remove old server activation

### DIFF
--- a/{{cookiecutter.python_name}}/binder/postBuild
+++ b/{{cookiecutter.python_name}}/binder/postBuild
@@ -36,14 +36,6 @@ _(
     sys.executable,
     "-m",
     "jupyter",
-    "serverextension",
-    "enable",
-    "{{ cookiecutter.python_name }}",
-)
-_(
-    sys.executable,
-    "-m",
-    "jupyter",
     "server",
     "extension",
     "enable",


### PR DESCRIPTION
Binder is now using Jupyter Server. Enabling the extension the old way is not needed - let's remove it.

> Ref https://discourse.jupyter.org/t/mybinder-org-and-repo2docker-updates/18333