### PR TITLE
Manual release: add clean-up instructions (pre-build)

### DIFF
--- a/{{cookiecutter.python_name}}/RELEASE.md
+++ b/{{cookiecutter.python_name}}/RELEASE.md
@@ -22,6 +22,18 @@ See the docs on [hatch-nodejs-version](https://github.com/agoose77/hatch-nodejs-
 hatch version <new-version>
 ```
 
+Make sure to clean up all the development files before building the package:
+
+```bash
+jlpm clean:all
+```
+
+And also clean up the local git repository:
+
+```bash
+git clean -dfX
+```
+
 To create a Python source package (`.tar.gz`) and the binary package (`.whl`) in the `dist/` directory, do:
 
 ```bash

--- a/{{cookiecutter.python_name}}/RELEASE.md
+++ b/{{cookiecutter.python_name}}/RELEASE.md
@@ -28,7 +28,7 @@ Make sure to clean up all the development files before building the package:
 jlpm clean:all
 ```
 
-And also clean up the local git repository:
+You could also clean up the local git repository:
 
 ```bash
 git clean -dfX


### PR DESCRIPTION
I had some issues with packages that I built by manually following the instructions here (e.g., wrong version number shown with `jupyter labextension list`) and it took me a while before I realize it was because I hadn't cleaned up my local development repository. 