### PR TITLE
Removes checkout step from isolated tests

### DIFF
--- a/{{cookiecutter.python_name}}/.github/workflows/build.yml
+++ b/{{cookiecutter.python_name}}/.github/workflows/build.yml
@@ -64,8 +64,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
     - name: Install Python
       uses: actions/setup-python@v4
       with:


### PR DESCRIPTION
The checkout step is unnecessary because we are testing the artifact we uploaded during the build workflow.